### PR TITLE
sh1106.py: Fix the pin numbers in the example code.

### DIFF
--- a/i2c/1106oled/sh1106.py
+++ b/i2c/1106oled/sh1106.py
@@ -27,13 +27,13 @@
 # Sample code sections
 # ------------ SPI ------------------
 # Pin Map SPI
-#   - 3v - xxxxxx   - Vcc
-#   - G  - xxxxxx   - Gnd
-#   - D7 - GPIO 13  - Din / MOSI fixed
-#   - D5 - GPIO 14  - Clk / Sck fixed
-#   - D8 - GPIO 4   - CS (optional, if the only connected device)
-#   - D2 - GPIO 5   - D/C
-#   - D1 - GPIO 2   - Res
+#   - 3V3      - Vcc
+#   - GND      - Gnd
+#   - GPIO 11  - DIN / MOSI fixed
+#   - GPIO 10  - CLK / Sck fixed
+#   - GPIO 4   - CS (optional, if the only connected device, connect to GND)
+#   - GPIO 5   - D/C
+#   - GPIO 2   - Res
 #
 # for CS, D/C and Res other ports may be chosen.
 #
@@ -50,21 +50,20 @@
 # --------------- I2C ------------------
 #
 # Pin Map I2C
-#   - 3v - xxxxxx   - Vcc
-#   - G  - xxxxxx   - Gnd
-#   - D2 - GPIO 5   - SCK / SCL
-#   - D1 - GPIO 4   - DIN / SDA
-#   - D0 - GPIO 16  - Res
-#   - G  - xxxxxx     CS
-#   - G  - xxxxxx     D/C
+#   - 3V3      - Vcc
+#   - GND      - Gnd
+#   - GPIO 5   - CLK / SCL
+#   - GPIO 4   - DIN / SDA
+#   - GPIO 2   - Res
+#   - GND      - CS
+#   - GND      - D/C
 #
-# Pin's for I2C can be set almost arbitrary
 #
 # from machine import Pin, I2C
 # import sh1106
 #
-# i2c = I2C(scl=Pin(5), sda=Pin(4), freq=400000)
-# display = sh1106.SH1106_I2C(128, 64, i2c, Pin(16), 0x3c)
+# i2c = I2C(0, scl=Pin(5), sda=Pin(4), freq=400000)
+# display = sh1106.SH1106_I2C(128, 64, i2c, Pin(2), 0x3c)
 # display.sleep(False)
 # display.fill(0)
 # display.text('Testing 1', 0, 0, 1)


### PR DESCRIPTION
The pins numbers of the example code in sh1106.py did not match the
RP2040 pins. Instead, pin numbers suitable for ESP8266 were listed.
