### PR TITLE
Change subtraction to addition to properly calculate temperature

### DIFF
--- a/adc/temperature.py
+++ b/adc/temperature.py
@@ -9,6 +9,6 @@ while True:
     
     # The temperature sensor measures the Vbe voltage of a biased bipolar diode, connected to the fifth ADC channel
     # Typically, Vbe = 0.706V at 27 degrees C, with a slope of -1.721mV (0.001721) per degree. 
-    temperature = 27 - (reading - 0.706)/0.001721
+    temperature = 27 + (reading - 0.706)/0.001721
     print(temperature)
     utime.sleep(2)


### PR DESCRIPTION
After following the example codes from: [Python SDK Doc](https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-python-sdk.pdf) and running them for myself I realized that the calculation of the current temperature is wrong.