### PR TITLE
remove superfluous "global"

### DIFF
--- a/blink/blink.py
+++ b/blink/blink.py
@@ -3,7 +3,6 @@ from machine import Pin, Timer
 led = Pin("LED", Pin.OUT)
 tim = Timer()
 def tick(timer):
-    global led
     led.toggle()
 
 tim.init(freq=2.5, mode=Timer.PERIODIC, callback=tick)


### PR DESCRIPTION
Unnecessary, as the variable isn't reassigned.