### PR TITLE
webserver.py: Change `Pin 15` to `Pin LED`

### DIFF
--- a/wireless/webserver.py
+++ b/wireless/webserver.py
@@ -4,7 +4,7 @@ import time
 
 from machine import Pin
 
-led = Pin(15, Pin.OUT)
+led = Pin("LED", Pin.OUT)
 
 ssid = 'YOUR NETWORK NAME'
 password = 'YOUR NETWORK PASSWORD'


### PR DESCRIPTION
This example does not work correctly RPI Pico W. Accessing the `light/on` and `light/off` endpoints does not toggle the LED state.

This patch fixes the issue.