### PR TITLE
Simple serial terminal example to run on Pico

### DIFF
--- a/uart/terminal/README.md
+++ b/uart/terminal/README.md
@@ -1,0 +1,20 @@
+# Pico serial terminal
+
+A simple example to allow a Pico to act as a serial terminal into another Raspberry Pi computer.
+Usefull for setting up a Pi when network setup fails for some reason.
+Should work for Windows, Linux, or Mac host machines.
+
+1. Add `enable_uart=1` to the Raspberry Pi computer `config.txt` and boot it.
+2. Connect pins `pico:{1,2,3}` to `pi:{10,8,6}`
+3. Connect to Pico using [Thonny][thonny]
+4. From Thonny, run `terminal.py` on Pico, then power up the Pi
+
+[thonny]: https://thonny.org/
+
+You should now have a serial terminal to your Raspberry Pi computer through your Pico.
+
+### Erratta / Bugs
+
+* Input is only taken a whole line at a time after the EOL character.
+* Line input is ALWAYS echoed back to the terminal as a new line, even passwords
+* Control characters are dropped so no curses tools (like `raspi-config`) work

--- a/uart/terminal/terminal.py
+++ b/uart/terminal/terminal.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env micropython
+from _thread import start_new_thread
+from machine import UART, Pin
+
+UART0 = 0 # uart0 is the FIRST uart
+TX=0      # Default Pin number for TX on Pico uart0
+RX=1      # Default Pin number for RX on Pico uart0
+VS=2      # comment reminder: DONT FORGET to connect the common Ground (VSS)
+
+uart = UART(UART0, 115200, parity=None, bits=8, stop=1, tx=Pin(TX, Pin.OUT), rx=Pin(RX, Pin.IN))
+
+# Type a line (plus enter) in REPL to transmit down UART
+def TX():
+    while True:
+        line = input() + "\n"
+        uart.write(line.encode())
+
+# Busy thread to relay EVERY character arriving from uart
+def RX():
+    while True:
+        recv = uart.read()
+        if(recv):
+            try:
+                print(recv.decode(), end='')
+            except UnicodeError:
+                # Caught a control char in buffer, eject it and move along
+                fix = [x for x in recv if x <= 127]
+                print(bytes(fix).decode(), end='')
+
+# Run busy thread on second processor
+start_new_thread(RX, tuple([]))
+# Run input wait on this (BSP) processor
+TX()


### PR DESCRIPTION
# Pico serial terminal

A simple example to allow a Pico to act as a serial terminal into another Raspberry Pi computer.
Usefull for setting up a Pi when network setup fails for some reason.
Should work for Windows, Linux, or Mac host machines.

1. Add `enable_uart=1` to the Raspberry Pi computer `config.txt` and boot it.
2. Connect pins `pico:{1,2,3}` to `pi:{10,8,6}`
3. Connect to Pico using [Thonny][thonny]
4. From Thonny, run `terminal.py` on Pico, then power up the Pi

[thonny]: https://thonny.org/

You should now have a serial terminal to your Raspberry Pi computer through your Pico.

### Erratta / Bugs

* Input is only taken a whole line at a time after the EOL character.
* Line input is ALWAYS echoed back to the terminal as a new line, even passwords
* Control characters are dropped so no curses tools (like `raspi-config`) work
