### PR TITLE
Revert "webserver.py: Change `Pin 15` to `Pin LED`"

### DIFF
--- a/wireless/webserver.py
+++ b/wireless/webserver.py
@@ -4,7 +4,7 @@ import time
 
 from machine import Pin
 
-led = Pin("LED", Pin.OUT)
+led = Pin(15, Pin.OUT)
 
 ssid = 'YOUR NETWORK NAME'
 password = 'YOUR NETWORK PASSWORD'


### PR DESCRIPTION
See section 3.9.2. This LED was never intended to be the on-board LED, it's supposed to be a LED attached to Pin 15 (the onboard LED on a Pico is Pin 25, not 15).